### PR TITLE
Create API route for pulling binned popularities

### DIFF
--- a/backend/app/controllers/stocks_controller.rb
+++ b/backend/app/controllers/stocks_controller.rb
@@ -65,11 +65,9 @@ class StocksController < ApplicationController
     min_popularity, max_popularity = minmax_docs.map { |doc| doc[:latest_popularity] }
 
     bucket_size = (max_popularity.to_f - min_popularity.to_f) / bucket_count.to_f
-    puts bucket_size
     binned_entries = entries.group_by do |elem|
       bucket_index = (elem[:latest_popularity].to_f / bucket_size).floor
       if bucket_index == bucket_count
-        puts elem
         bucket_index -= 1
       end
 

--- a/backend/app/models/popularity.rb
+++ b/backend/app/models/popularity.rb
@@ -135,4 +135,12 @@ class Popularity
       { "$limit" => limit },
     ].compact)
   end
+
+  def self.bucket_popularity(bucket_count)
+    entries = MongoClient[:popularity].aggregate([
+      { "$match": { timestamp: { "$gte": 2.hours.ago.utc } } },
+      { "$sort": { timestamp: -1 } },
+      { "$group": { _id: "$instrument_id", latest_popularity: { "$first": "$popularity" } } },
+    ])
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get :least_popular, to: "stocks#least_popular", defaults: { format: :json }
   get :quotes, to: "stocks#quotes", defaults: { format: :json }
   get :total_symbols, to: "stocks#total_symbols", defaults: { format: :json }
+  get :popularity_bins, to: "stocks#popularity_bins", defaults: { format: :json }
 
   resources :stocks, only: [], id: /[A-Z0-9\.]+?/i, defaults: { format: :json } do
     member do


### PR DESCRIPTION
 * Pulls the most recent popularity for each symbol from the database, generates `n` evenly sized buckets by popularity, and distributes elements into them.
 * Returns the buckets containing how many popularities fit into each of them as well as the min and max popularity for the whole set.